### PR TITLE
Update vulnerable plugin dependency using constraint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,15 @@
+// Constrain 'com.squareup.okio:okio' to avoid https://github.com/advisories/GHSA-w33c-445m-f8w7
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        constraints {
+            classpath(libs.okio)
+        }
+    }
+}
+
 plugins {
     alias(libs.plugins.versions)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@
 commons-text = { module = "org.apache.commons:commons-text", version = "1.9" }
 minio = { module = "io.minio:minio", version = "8.5.8" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version = "5.10.2" }
+okio = { module = "com.squareup.okio:okio", version = "3.4.0" }
 
 [plugins]
 versions = { id = "com.github.ben-manes.versions", version = "0.51.0" }


### PR DESCRIPTION
The 'com.github.ben-manes.versions' plugin' has a dependency on a vulnerable version of 'com.squareup.okio:okio'.

Assuming there is no fixed version of the plugin available, we avoid this vulnerability using a dependency constraint that causes a newer version of 'okio' to be used in the buildscript classpath.